### PR TITLE
Add rudimentary support for transfer when calling postMessage

### DIFF
--- a/src/EasyWebWorker.ts
+++ b/src/EasyWebWorker.ts
@@ -274,7 +274,7 @@ export class EasyWebWorker<TPayload = null, TResult = void> {
   public onWorkerError: (error: ErrorEvent) => void;
 
   protected get isExternalWorkerFile(): boolean {
-    return typeof this.source === "string";
+    return typeof this.source === 'string';
   }
 
   constructor(
@@ -482,7 +482,10 @@ export class EasyWebWorker<TPayload = null, TResult = void> {
     return this.sendToWorker<TPayload, TResult>({ payload }, transfer);
   }) as unknown as TPayload extends null
     ? () => CancelablePromise<TResult>
-    : (payload: TPayload, transfer?: Transferable[]) => CancelablePromise<TResult>;
+    : (
+        payload: TPayload,
+        transfer?: Transferable[]
+      ) => CancelablePromise<TResult>;
 
   private sendToWorker = <TPayload_ = null, TResult_ = void>(
     {
@@ -597,7 +600,7 @@ export class EasyWebWorker<TPayload = null, TResult = void> {
    * This method will reboot the worker and cancel all the messages in the queue
    * @param {unknown} reason - reason why the worker will be restarted
    */
-  public reboot(reason: unknown = "Worker was rebooted") {
+  public reboot(reason: unknown = 'Worker was rebooted') {
     this.worker.terminate();
     this.worker = null;
 

--- a/src/EasyWebWorkerParallel.ts
+++ b/src/EasyWebWorkerParallel.ts
@@ -77,7 +77,7 @@ export class EasyWebWorkerParallel<TPayload = null, TResult = void> {
     new Map();
 
   protected get isExternalWorkerFile(): boolean {
-    return typeof this.source === "string";
+    return typeof this.source === 'string';
   }
 
   constructor(
@@ -220,13 +220,13 @@ export class EasyWebWorkerParallel<TPayload = null, TResult = void> {
     isArrayOfWebWorkers: boolean;
     isArraySource?: boolean;
   } {
-    const isUrlBase = typeof this.source === "string";
-    const isFunctionTemplate = typeof this.source === "function";
+    const isUrlBase = typeof this.source === 'string';
+    const isFunctionTemplate = typeof this.source === 'function';
 
     const isArraySource = Array.isArray(this.source);
 
     const isArrayOfFunctions =
-      isArraySource && typeof this.source[0] === "function";
+      isArraySource && typeof this.source[0] === 'function';
 
     const isArrayOfWebWorkers =
       isArraySource && this.source[0] instanceof Worker;


### PR DESCRIPTION
I'm using your library to render to an `OffscreenCanvas` in a Web Worker. I create a `canvas` in the main thread and use `const offscreenCanvas = myCanvas.transferControlToOffscreen()`, then send it to the worker with `postMessage`.

Your library mostly supports this, but `postMessage` needs a second argument for `Transferable` objects like `OffscreenCanvas`. This tells the browser to move the object's memory and ownership to the worker.

I added this feature to your library and would appreciate if you could review my changes. I changed the `send` method's signature, which might have altered your original intent. Please let me know if there's anything I should change.