### PR TITLE
Add missing parameter and type definition for transfer

### DIFF
--- a/src/EasyWebWorker.ts
+++ b/src/EasyWebWorker.ts
@@ -783,7 +783,10 @@ export class EasyWebWorker<
     return this.sendToWorker<TPayload, TResult>({ payload }, transfer);
   }) as [TPayload] extends [null]
     ? () => CancelablePromise<TResult>
-    : (payload: TPayload) => CancelablePromise<TResult>;
+    : (
+        payload: TPayload,
+        transfer?: Transferable[]
+      ) => CancelablePromise<TResult>;
 
   private sendToWorker = <TPayload_ = null, TResult_ = void>(
     {
@@ -845,7 +848,7 @@ export class EasyWebWorker<
       },
     };
 
-    worker.postMessage(data);
+    worker.postMessage(data, transfer);
 
     return decoupledPromise.promise;
   };


### PR DESCRIPTION
In my PR #7 I forgot two things:
* Adding the `transfer` parameter to both calls of `postMessage`
* Adding the `transfer` parameter to the definition of the method `send`

This PR corrects that.